### PR TITLE
In the DID spec, this is now called "deactivate" instead of "delete/r…

### DIFF
--- a/src/interfaces/DIDMethod.kt
+++ b/src/interfaces/DIDMethod.kt
@@ -7,6 +7,6 @@ interface DID {
   fun create()
   fun veirify()
   fun update()
-  fun delete()
+  fun deactivate()
 
 }


### PR DESCRIPTION
…evoke".

Signed-off-by: Markus Sabadello <markus@danubetech.com>